### PR TITLE
Add namespace selector to the prom deployment

### DIFF
--- a/manifests/prometheus/prometheus-k8s.yaml
+++ b/manifests/prometheus/prometheus-k8s.yaml
@@ -20,6 +20,9 @@ spec:
   serviceMonitorSelector:
     matchExpressions:
     - {key: k8s-app, operator: Exists}
+  serviceMonitorNamespaceSelector:
+    matchExpressions:
+    - {key: prometheus-monitoring, operator: In, values: ["enabled"]}
   ruleSelector:
     matchLabels:
       role: prometheus-rulefiles


### PR DESCRIPTION
**What**
- Add namespace selector to allow the prometheus deployment to read
ServiceMonitor defitions from namespaces labeld `prometheus-monitoring: enabled`

**Why**
- For any namespace we label with `prometheus-monitoring: enabled`, the
central prometheus deployment will register ServiceMonitors that have a
`k8s-app` label.  This will allow us to centralize the metrics in a
single interface

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>